### PR TITLE
Add CLI argument for OUI database path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::{HashMap, HashSet}, ops::{Deref, DerefMut}};
+use std::{collections::{HashMap, HashSet}, ops::{Deref, DerefMut}, fs};
 use eui48::MacAddress;
 use pcap::{Capture, Device};
 use radiotap::Radiotap;
@@ -34,10 +34,20 @@ fn main() {
                 .long("dont-monitor")
                 .help("Don't try entering monitor mode using libpcap")
         )
+        .arg(
+            Arg::with_name("database")
+                .short("-f")
+                .long("dbfile")
+                .help("Specify the path to the OUI database file")
+                .default_value("oui_database")
+        )
         .get_matches();
     
     println!("Parsing Manufacturer Names");
-    let oui_db = OuiDatabase::new_from_str(include_str!("oui_database")).expect("Failed to parse MAC address lookup database");
+    let oui_db = match fs::read_to_string(args.value_of("database").unwrap()) {
+        Ok(s) => OuiDatabase::new_from_str(&s).expect("Failed to parse MAC address lookup database"),
+        Err(e) => panic!("Failed to open database file: {:?}", e),
+    };
 
     let mut ui = ui::Ui::new();
 


### PR DESCRIPTION
Just a small PR to replace loading in the database at compile time with loading it in at runtime from a user-defined path (defaults to "./oui-database"), in case someone wants to load a custom (or updated) database. 

On second thought, im not sure this is the way to go about it. Maybe it'd be better to stick to the current way but have a build script that pulls the latest database from the Wireshark repo? Thoughts?